### PR TITLE
Add an option to enable cookie refreshing

### DIFF
--- a/options.go
+++ b/options.go
@@ -113,3 +113,10 @@ func TTLField(ttlField string) Option {
 		s.ttlField = ttlField
 	}
 }
+
+// RefreshCookies allows existing sesison cookies to be updated on save
+func RefreshCookies() Option {
+	return func(s *Store) {
+		s.refreshCookies = true
+	}
+}


### PR DESCRIPTION
### Summary

Adds a new option to allow refreshing of existing session cookies (off by default).

Currently, when the MaxAge option is provided, the value of the TTL field in the DynamoDB store will be updated on each save, however the cookie will not. Even if the value of the TTL field in the DynamoDB store is extended, the cookie will still expire at the original MaxAge.

This change allows for the associated session cookie's TTL to be updated similarly by letting it be recreated.

### Changes

- New refreshCookies (bool) field on Store
- New RefreshCookies() Option that when provided sets Store.refreshCookies to true
- Changed logic determining if the session cookie can be set on save
  - Before: If session is not new, do nothing ; otherwise create and set cookie
  - After: If session is new or if Store.refreshCookies is true, create and set the cookie ; otherwise do nothing